### PR TITLE
Update tfsec-pipelines.yml

### DIFF
--- a/tfsec/tfsec-pipelines.yml
+++ b/tfsec/tfsec-pipelines.yml
@@ -8,12 +8,15 @@ parameters:
 steps:
 - checkout: self
 - bash: mkdir ${{parameters.WorkingDirectory}}/TFSecReport
+  displayName: 'tfsec - Create output directory'
 - bash: docker run --rm -v ${{parameters.WorkingDirectory}}:/src aquasec/tfsec /src --exclude ${{parameters.Exclusions}} --include-passed
+  displayName: 'tfsec - Scan terraform'
 - bash: docker run --rm -v ${{parameters.WorkingDirectory}}:/src aquasec/tfsec /src --exclude ${{parameters.Exclusions}} --include-passed --format JUnit > ${{parameters.WorkingDirectory}}/TFSecReport/TFSec-Report.xml
+  displayName: 'tfsec - Create scan results report'
   condition: always()
  # Publish the results of the TFSec analysis as Test Results to the pipeline
 - task: PublishTestResults@2
-  displayName: Publish TFSecReport Test Results
+  displayName: 'tfsec - Publish scan results report'
   condition: succeededOrFailed()
   inputs:
     testResultsFormat: 'JUnit' # Options JUnit, NUnit, VSTest, xUnit, cTest


### PR DESCRIPTION
(Update: Sorry for the confusing branch name of `bensloanukho-patch-1`. I am not entirely familiar with Github and missed the point where I was setting this name up in the Github UI!)

Without specifying the display name of the bash steps, when running the pipeline the steps simply show as 'Bash Bash Bash'. Which sounds pretty cool in all fairness, but doesn't give all the context to the runs.

To give this context, I have added the `displayName` element to the bash steps; with a common `tfsec - ` prefix.

How was this tested: I copied/pasted the steps directly into an existing Azure Pipeline in place of using the template to verify it would work as expected. The pipeline runs are linked below so you can see the before/after.

Example of before: 
https://dev.azure.com/ukhydro/External%20Data%20Upload/_build/results?buildId=145943&view=logs&j=ee448448-853a-5c65-9e94-ba495316676c

Example of after: 
https://dev.azure.com/ukhydro/External%20Data%20Upload/_build/results?buildId=146016&view=logs&j=ee448448-853a-5c65-9e94-ba495316676c