### PR TITLE
gated-infrastructure-deploy parameter TerraformOutputVariables enforced optional 

### DIFF
--- a/gated-infrastructure-deploy/README.md
+++ b/gated-infrastructure-deploy/README.md
@@ -55,19 +55,19 @@ For a complete working example, please refer to the [acg-connect](https://github
 
 3. Consult the table below to fill out each of the parameters with the value that you require.
 
-    | parameter | Required | Type | Description | 
-    | - | - | - | - | 
-    | AzDOEnvironmentName | Yes | string | Environment name as defined in Azure DevOps |
-    | TFStateResourceGroupName | Yes | string | Terraform state resource group |
-    | TFStateStorageAccountName | Yes | string | Terraform state storage account |
-    | TFStateContainerName | Yes | string | Terraform state container |
-    | TFStateBlobName | Yes| string | Terraform state blob |
-    | TerraformWorkspace | Yes | string | Terraform workspace |
-    | TerraformArtifact| Yes | string | Artifact containing your .tf files and any other supporting files for your deployment |
-    | TerraformArtifactConfigRelativePath | Yes | string | Relative path to the .tf files inside your artifact |
-    | VariablesTemplateRelativePath | Yes | string | Relative path to a YAML template containing a variables expression |
-    | TerraformVariableMappings | Yes | object | A key/value map of Terraform variables to be injected into the PowerShell runtime environment for Terraform to use |
-    | TerraformOutputVariables| No | object | An array of Terraform output variables to be retrieved after the Terraform apply has completed |
+    | parameter                           | Required | Type   | Description                                                                                                        | 
+    |-------------------------------------|----------|--------|--------------------------------------------------------------------------------------------------------------------| 
+    | AzDOEnvironmentName                 | Yes      | string | Environment name as defined in Azure DevOps                                                                        |
+    | TFStateResourceGroupName            | Yes      | string | Terraform state resource group                                                                                     |
+    | TFStateStorageAccountName           | Yes      | string | Terraform state storage account                                                                                    |
+    | TFStateContainerName                | Yes      | string | Terraform state container                                                                                          |
+    | TFStateBlobName                     | Yes      | string | Terraform state blob                                                                                               |
+    | TerraformWorkspace                  | Yes      | string | Terraform workspace                                                                                                |
+    | TerraformArtifact                   | Yes      | string | Artifact containing your .tf files and any other supporting files for your deployment                              |
+    | TerraformArtifactConfigRelativePath | Yes      | string | Relative path to the .tf files inside your artifact                                                                |
+    | VariablesTemplateRelativePath       | Yes      | string | Relative path to a YAML template containing a variables expression                                                 |
+    | TerraformVariableMappings           | Yes      | object | A key/value map of Terraform variables to be injected into the PowerShell runtime environment for Terraform to use |
+    | TerraformOutputVariables            | No       | object | An array of Terraform output variables to be retrieved after the Terraform apply has completed                     |
 
     **Notes**:
 

--- a/gated-infrastructure-deploy/README.md
+++ b/gated-infrastructure-deploy/README.md
@@ -49,7 +49,7 @@ For a complete working example, please refer to the [acg-connect](https://github
           VariablesTemplateRelativePath: "string"
           TerraformVariableMappings:
             TERRAFORM_VARIABLE: "VALUE" 
-          TerraformOutputVariables:
+          TerraformOutputVariables: # optional
             POSSIBLE_TERRAFORM_OUTPUT_VARIABLE
     ```
 

--- a/gated-infrastructure-deploy/gated-infrastructure-deploy.yml
+++ b/gated-infrastructure-deploy/gated-infrastructure-deploy.yml
@@ -21,6 +21,7 @@
     type: object
   - name: TerraformOutputVariables
     type: object
+    default: {}
   - name: TerraformContainer
     type: string
     default: ''

--- a/gated-infrastructure-deploy/terraform-cmdlets.ps1
+++ b/gated-infrastructure-deploy/terraform-cmdlets.ps1
@@ -124,7 +124,7 @@ function Terraform-Apply {
 function ExportRequiredTerraformOutputVariables {
   [CmdletBinding()]
   param (
-    [Parameter(Mandatory)]
+    [Parameter()]
     [string] $TerraformOutputVariables
   )
 

--- a/gated-infrastructure-deploy/terraform-cmdlets.ps1
+++ b/gated-infrastructure-deploy/terraform-cmdlets.ps1
@@ -125,7 +125,6 @@ function ExportRequiredTerraformOutputVariables {
   [CmdletBinding()]
   param (
     [Parameter(Mandatory)]
-    [ValidateNotNullOrEmpty()]
     [string] $TerraformOutputVariables
   )
 


### PR DESCRIPTION
Parameter `TerraformOutputVariables` was meant to be optional but never was, now it is optional