### PR TITLE
Add Snyk Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Below is a summary of the templates we have available
 | [Checkov](./checkov)                                         | Terraform scanning to ensure that there is no security misconfiguration in your terraform files                                                    |
 | [Github Tag](./github-tag)                                   | Github tags to your commits for marking significant points in a project's development                                                              |
 | [Retain pipeline run](./retain-pipelinerun)                  | Retaining a pipeline run for longer than the default configured 30 days after production release                                                   |
-| [SAST](./sast)                                               | SAST scan of the dotnet projects                                                                                                                   |
+| [Snyk](./snyk)                                               | Snyk pipeline runs for SAST, SCA, IAC and Container scanning projects                                                                                                                   |
 | [Trivy](./trivy)                                             | Static analysis security scanner against your Terraform                                                                                            |
 | [Gated Infrastructure Deploy](./gated-infrastructure-deploy) | Will trigger manual validation step if Terraform `plan` detects resource destruction |

--- a/snyk/README.md
+++ b/snyk/README.md
@@ -36,6 +36,20 @@ steps:
 | `codeSeverityThreshold` | The severity threshold of code SAST scanning. Anything below the threshold will be ignored | false     | medium  |
 | `additionalArguments`   | Any additional arguments to run with the command. [Commands can be found here](https://docs.snyk.io/snyk-cli/cli-commands-and-options-summary#options-for-multiple-commands)                                                        | false     | ''      |
 
+## Test Types
+
+### SCA
+This test type will perform a scan of your dependencies and feedback if there are any vulnerabilities found. To do this it performs a dotnet restore using the dotnet cli task with the dotnet version set to 8.x.
+
+### Container
+This test type will perform a scan of the built container and feedback if there are any vulnerabilities found. To do this it builds the container using the image name provided and then performs the scan.
+
+### IAC
+This test type will perform a scan of infrastructure as code and feedback if there are any vulnerabilities found. This can scan the repo or a single file. To specify file you can pass in the file path via the `targetFile` parameter.
+
+### Code
+This test type will perform a scan of the code and feedback if there are any vulnerabilities found. This is similar to the PR scan that is performed however you can stop your pipeline with this check.
+
 ## Results
 
 The template uses the `PublishPipelineArtifact` built in task to output the scan results in a json format. The logs will show a more human readable version for analysis however for reference we will output this file. If there are no issues, there will be no file published. Results from the pipeline are not monitored in the dashboard to allow for engineers to adjust and make changes without affecting overall metrics.

--- a/snyk/README.md
+++ b/snyk/README.md
@@ -1,0 +1,45 @@
+# Snyk Azure Pipelines Build Template
+This repo contains the pipeline template required to run the snyk scans available against your repository.
+
+## Usage
+
+Reference this repository in the pipeline yaml
+```yaml
+resources:
+  repositories:
+    - repository: UKHOTemplates
+      type: github
+      endpoint: Your_Github_Service_Connection_Name
+      name: UKHO/devops-pipelinetemplates
+```
+
+Add to your jobs steps
+
+```yaml
+steps:
+  - template: snyk/snyk-pipeline-run.yml@UKHOTemplates
+    parameters:
+      organization: $(organization)
+```
+
+## Parameters
+
+| Name                    | Description                                                                                | Required? | Default |
+|-------------------------|--------------------------------------------------------------------------------------------|-----------|---------|
+| `organization`          | The GUID of the organization for which the scan is to be run                               | true      | ''      |
+| `serviceConnectionToken`| A Service Account token to which can be authenticated to the organization                  | true      | ''      |
+| `testType`              | The type of test to run. Available values are `sca|code|iac|container`                     | false     | sca     |
+| `dockerImageName`       | The name of the docker image to be built and scanned                                       | false     | ''      |
+| `dockerfilePath`        | The path to dockerfile that is being scanned                                               | false     | ''      |
+| `targetFile`            | The name of the sln to be used in the SCA scanning                                         | false     | ''      |
+| `severityThreshold`     | The severity threshold of vuln scanning. Anything below the threshold will be ignored      | false     | medium  |
+| `codeSeverityThreshold` | The severity threshold of code SAST scanning. Anything below the threshold will be ignored | false     | medium  |
+| `additionalArguments`   | Any additional arguments to run with the command. [Commands can be found here](https://docs.snyk.io/snyk-cli/cli-commands-and-options-summary#options-for-multiple-commands)                                                        | false     | ''      |
+
+## Results
+
+The template uses the `PublishPipelineArtifact` built in task to output the scan results in a json format. The logs will show a more human readable version for analysis however for reference we will output this file. If there are no issues, there will be no file published. Results from the pipeline are not monitored in the dashboard to allow for engineers to adjust and make changes without affecting overall metrics.
+
+## Suppressions
+
+Suppressions should be performed from the Snyk interface rather than using other methods. This is so that the Cyber Security team can properly audit suppressions and where there are remediation they should be dealt with immediately and not delayed. 

--- a/snyk/snyk-cli-download.yml
+++ b/snyk/snyk-cli-download.yml
@@ -1,0 +1,10 @@
+steps:
+  - script: |
+      curl --compressed https://downloads.snyk.io/cli/stable/snyk-linux -o snyk
+      chmod +x ./snyk
+      mv ./snyk $(Agent.ToolsDirectory)
+      echo "##vso[task.setvariable variable=PATH;]${PATH}:$(Agent.ToolsDirectory)"
+    displayName: Download Snyk CLI
+  - script: |
+      snyk --version
+    displayName: Display Snyk Version

--- a/snyk/snyk-code-scan.yml
+++ b/snyk/snyk-code-scan.yml
@@ -1,0 +1,29 @@
+parameters:
+  - name: organization
+    displayName: Organization ID in Snyk
+    type: string
+  - name: serviceConnectionToken
+    displayName: Snyk Service Account Token
+    type: string
+  - name: codeSeverityThreshold
+    displayName: Code testing severity threshold
+    type: string
+  - name: additionalArguments
+    displayName: Additional command-line args for Snyk CLI 
+    type: string
+
+steps:
+  - script: |
+      SNYK_TOKEN=${{ parameters.serviceConnectionToken }} snyk code test \
+      --org=${{ parameters.organization }} \
+      --severity-threshold=${{ parameters.codeSeverityThreshold }} \
+      --json-file-output=code-results.json \
+      ${{ parameters.additionalArguments }}
+    displayName: Perform SAST Scan
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/code-results.json
+      artifact: code-results.json
+      publishLocation: 'pipeline'
+    displayName: 'Publish artifact: CodeScanningResults'
+    condition: failed()

--- a/snyk/snyk-container-scan.yml
+++ b/snyk/snyk-container-scan.yml
@@ -1,0 +1,37 @@
+parameters:
+  - name: organization
+    displayName: Organization ID in Snyk
+    type: string
+  - name: serviceConnectionToken
+    displayName: Snyk Service Account Token
+    type: string
+  - name: dockerImageName
+    displayName: Container Image Name
+    type: string
+  - name: dockerfilePath
+    displayName: Path to Dockerfile
+    type: string
+  - name: severityThreshold
+    displayName: Testing severity threshold
+    type: string
+  - name: additionalArguments
+    displayName: Additional command-line args for Snyk CLI 
+    type: string
+
+steps:
+  - script: |
+      SNYK_TOKEN=${{ parameters.serviceConnectionToken }} snyk container test ${{ parameters.dockerImageName}} \
+      --org=${{ parameters.organization }} \
+      --file=${{ parameters.dockerfilePath }} \
+      --severity-threshold=${{ parameters.severityThreshold }} \
+      --json-file-output=container-results.json \
+      --app-vulns \
+      ${{ parameters.additionalArguments }}
+    displayName: Perform Container Scan
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/container-results.json
+      artifact: container-results.json
+      publishLocation: 'pipeline'
+    displayName: 'Publish artifact: CodeScanningResults'
+    condition: always()

--- a/snyk/snyk-iac-scan.yml
+++ b/snyk/snyk-iac-scan.yml
@@ -1,0 +1,32 @@
+parameters:
+  - name: organization
+    displayName: Organization ID in Snyk
+    type: string
+  - name: serviceConnectionToken
+    displayName: Snyk Service Account Token
+    type: string
+  - name: targetFile
+    displayName: Custom path to manifest file to test
+    type: string
+  - name: severityThreshold
+    displayName: Testing severity threshold
+    type: string
+  - name: additionalArguments
+    displayName: Additional command-line args for Snyk CLI 
+    type: string
+
+steps:
+  - script: |
+      SNYK_TOKEN=${{ parameters.serviceConnectionToken }} snyk iac test ${{ parameters.targetFile }} \
+      --org=${{ parameters.organization }} \
+      --severity-threshold=${{ parameters.severityThreshold }} \
+      --json-file-output=iac-results.json \
+      ${{ parameters.additionalArguments }}
+    displayName: Perform IAC Scan
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/iac-results.json
+      artifact: iac-results.json
+      publishLocation: 'pipeline'
+    displayName: 'Publish artifact: CodeScanningResults'
+    condition: always()

--- a/snyk/snyk-pipeline-run.yml
+++ b/snyk/snyk-pipeline-run.yml
@@ -1,0 +1,123 @@
+parameters:
+  - name: organization
+    displayName: Organization ID in Snyk
+    type: string
+    default: ''
+  - name: serviceConnectionToken
+    displayName: Snyk Service Account Token
+    type: string
+    default: ''
+  - name: testType
+    displayName: Scan Type
+    type: string
+    default: sca
+    values:
+    - sca
+    - code
+    - container
+    - iac
+  - name: dockerImageName
+    displayName: Container Image Name
+    type: string
+    default: ''
+  - name: dockerfilePath
+    displayName: Path to Dockerfile
+    type: string
+    default: ''
+  - name: targetFile
+    displayName: Custom path to manifest file to test
+    type: string
+    default: ''
+  - name: severityThreshold
+    displayName: Testing severity threshold
+    type: string
+    default: medium
+    values:
+    - low
+    - medium
+    - high
+    - critical
+  - name: codeSeverityThreshold
+    displayName: Code testing severity threshold
+    type: string
+    default: medium
+    values:
+    - low
+    - medium
+    - high
+  - name: additionalArguments
+    displayName: Additional command-line args for Snyk CLI 
+    type: string
+    default: ''
+
+jobs:
+- ${{ if contains(parameters.testType, 'sca')}}:
+  - job: sca
+    displayName: Snyk SCA Scan
+    steps:
+    - task: UseDotNet@2
+      displayName: 'Install .NET Core SDK'
+      inputs:
+        version: 8.x
+        performMultiLevelLookup: true
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'custom'
+        custom: 'workload'
+        arguments: 'restore'
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'restore'
+    - template: snyk-cli-download.yml
+    - template: snyk-sca-scan.yml
+      parameters:
+        organization: ${{ parameters.organization }}
+        serviceConnectionToken: ${{ parameters.serviceConnectionToken }}
+        severityThreshold: ${{ parameters.severityThreshold }}
+        additionalArguments: ${{ parameters.additionalArguments }}
+        targetFile: ${{ parameters.targetFile }}
+
+- ${{ if contains(parameters.testType, 'container')}}:
+  - job: container
+    displayName: Snyk Container Scan
+    steps:
+    - task: Docker@2
+      displayName: Build an image
+      inputs:
+        repository: ${{ parameters.dockerImageName }}
+        command: build
+        Dockerfile: ${{ parameters.dockerfilePath }}
+    - template: snyk-cli-download.yml
+    - template: snyk-container-scan.yml
+      parameters:
+        organization: ${{ parameters.organization }}
+        serviceConnectionToken: ${{ parameters.serviceConnectionToken }}
+        dockerImageName: ${{ parameters.dockerImageName }}
+        dockerfilePath: ${{ parameters.dockerfilePath }}
+        severityThreshold: ${{ parameters.severityThreshold }}
+        additionalArguments: ${{ parameters.additionalArguments }}
+
+- ${{ if contains(parameters.testType, 'code')}}:
+  - job: code
+    displayName: Snyk SAST Scan
+    steps:
+    - template: snyk-cli-download.yml
+    - template: snyk-code-scan.yml
+      parameters:
+        organization: ${{ parameters.organization }}
+        serviceConnectionToken: ${{ parameters.serviceConnectionToken }}
+        codeSeverityThreshold: ${{ parameters.codeSeverityThreshold }}
+        additionalArguments: ${{ parameters.additionalArguments }}
+
+- ${{ if contains(parameters.testType, 'iac')}}:
+  - job: iac
+    displayName: Snyk Infrastructure-As-Code Scan
+    steps:
+    - template: snyk-cli-download.yml
+    - template: snyk-iac-scan.yml
+      parameters:
+        organization: ${{ parameters.organization }}
+        serviceConnectionToken: ${{ parameters.serviceConnectionToken }}
+        targetFile: ${{ parameters.targetFile }}
+        severityThreshold: ${{ parameters.severityThreshold }}
+        additionalArguments: ${{ parameters.additionalArguments }}

--- a/snyk/snyk-sca-scan.yml
+++ b/snyk/snyk-sca-scan.yml
@@ -1,0 +1,33 @@
+parameters:
+  - name: organization
+    displayName: Organization ID in Snyk
+    type: string
+  - name: serviceConnectionToken
+    displayName: Snyk Service Account Token
+    type: string
+  - name: targetFile
+    displayName: Custom path to manifest file to test
+    type: string
+  - name: severityThreshold
+    displayName: Testing severity threshold
+    type: string
+  - name: additionalArguments
+    displayName: Additional command-line args for Snyk CLI 
+    type: string
+
+steps:
+  - script: |
+      SNYK_TOKEN=${{ parameters.serviceConnectionToken }} snyk test \
+      --org=${{ parameters.organization }} \
+      --severity-threshold=${{ parameters.severityThreshold }} \
+      --file=${{ parameters.targetFile }} \
+      --json-file-output=sca-results.json \
+      ${{ parameters.additionalArguments }}
+    displayName: Perform SCA Scan
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(System.DefaultWorkingDirectory)/sca-results.json
+      artifact: sca-results.json
+      publishLocation: 'pipeline'
+    displayName: 'Publish artifact: CodeScanningResults'
+    condition: always()


### PR DESCRIPTION
# What has been done
Added a set of templates for Snyk to allow for utilization of the different scan types. This is because the built in task only performs some of the scans and we want to be able to provide the teams with all the functionality.

The templates have been split up into their separate components (SCA, Code, IAC and Container) with a single runner to call them all. This is to enable an easy entry point but also the ability for engineers to pull in just what they need with more complex pipelines. 

To ensure we are always using the latest CLI, there is a step to download and display the version. This is useful in the case that we need to debug any issues or need to report any problems to Snyk themselves. 